### PR TITLE
Layout Adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 dist
 .env
 .env.*
+.vsCode/

--- a/src/components/AuthorCard.vue
+++ b/src/components/AuthorCard.vue
@@ -24,7 +24,7 @@
       </div>
 
       <div class="content">
-        Hell. Put a descriptioin of the author or site here. :)
+        Hello! Put a description of the author or site here. :)
         <br />
       </div>
     </div>

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -1,17 +1,19 @@
 <template>
-  <section class="section">
-    <div class="container">
-      <div class="columns is-multiline is-desktop">
-        <div class="column is-one-quarter is-narrow">
-          <AuthorCard />
-        </div>
-        <div class="column">
-          <slot />
+  <body>
+    <section class="section">
+      <div class="container">
+        <div class="columns is-multiline is-desktop">
+          <div class="column is-one-quarter is-narrow">
+            <AuthorCard />
+          </div>
+          <div class="column">
+            <slot />
+          </div>
         </div>
       </div>
-    </div>
+    </section>
     <Footer />
-  </section>
+  </body>
 </template>
 
 <static-query>
@@ -28,7 +30,7 @@ import Footer from "~/components/Footer.vue";
 export default {
   components: {
     AuthorCard,
-    Footer
-  }
+    Footer,
+  },
 };
 </script>

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -1,5 +1,5 @@
 <template>
-  <body>
+  <div>
     <section class="section">
       <div class="container">
         <div class="columns is-multiline is-desktop">
@@ -13,7 +13,7 @@
       </div>
     </section>
     <Footer />
-  </body>
+  </div>
 </template>
 
 <static-query>

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -34,3 +34,12 @@ export default {
   },
 };
 </script>
+
+<style>
+  #app {
+    min-height: 100vh;
+    display: flex; 
+    flex-direction: column;
+    justify-content: space-between;
+  }
+</style>

--- a/src/templates/Post.vue
+++ b/src/templates/Post.vue
@@ -1,27 +1,19 @@
 <template>
-  <section class="section">
-    <div class="container">
-      <div class="columns is-desktop">
-        <div class="column is-one-quarter is-narrow">
-          <AuthorCard />
-        </div>
-        <div class="column">
-          <a class="icon" href="/">
-            <i class="fa fa-arrow-left fa-2x"></i>
-          </a>
-          <h1 class="title">{{ $page.post.title }}</h1>
-          <em>{{ $page.post.date }}</em>
-          <div class="content" v-html="$page.post.content" />
+  <Layout>
+    <a class="icon" href="/">
+      <i class="fa fa-arrow-left fa-2x"></i>
+    </a>
+    <h1 class="title">{{ $page.post.title }}</h1>
+    <em>{{ $page.post.date }}</em>
+    <div class="content" v-html="$page.post.content" />
 
-          <div class="post-comments">
-            <vue-disqus shortname="DISQUSSHORTNAME" :identifier="$page.post.title"></vue-disqus>
-          </div>
-        </div>
-      </div>
+    <div class="post-comments">
+      <vue-disqus
+        shortname="DISQUSSHORTNAME"
+        :identifier="$page.post.title"
+      ></vue-disqus>
     </div>
-    <br />
-    <Footer />
-  </section>
+  </Layout>
 </template>
 
 <script>
@@ -30,7 +22,7 @@ import Footer from "~/components/Footer.vue";
 export default {
   components: {
     AuthorCard,
-    Footer
+    Footer,
   },
   metaInfo() {
     return {
@@ -38,11 +30,11 @@ export default {
       meta: [
         {
           name: "description",
-          content: this.$page.post.description
-        }
-      ]
+          content: this.$page.post.description,
+        },
+      ],
     };
-  }
+  },
 };
 </script>
 


### PR DESCRIPTION
I really like how clean the UI for this starter is and built this PR to make some adjustments to make the UI just a bit cleaner for users looking to use this starter: 

## Fix typos in Author Card Component

Hello was missing an 'o' and description was mistyped :) 

## Utilize Layout Component in `Post.vue`

`Layout.vue` is being imported globally to the site, but is not being used in `Post.vue` - this removes duplicate code and will keep the interface consistent across pages as future users make adjustments to their Layout. 

## App will now fill the page

I added CSS to `#app` to ensure that when there isn't enough content to push the footer to the bottom of the page, it still appears at the bottom of the page. I used flexbox and min-height to achieve this. 

## Footer outside of `<section>`

The Footer component was listed inside of the `<section class="section">` element, causing it to have padding preventing it from stretching the width of the page, and preventing it from ever touching the bottom of the page. 

Because Vue 2 doesn't allow multiple root elements, I added a `<div>` to `Layout.vue` - ideally down the road Gridsome will allow the body to be designated inside of the layout instead of always populating it as a default so that the section can be listed immediately inside of the body tag how Bulma recommends. 

---

Awesome work with the starter! Let me know if you have any questions about the tweaks! 